### PR TITLE
ci: Fix broken tests & add GitHub Action to build Rust & execute tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "mainline" ]
+  pull_request:
+    branches: [ "mainline" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,10 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case(2, None)]
-    #[case(4, Some(Telemetry::default()))]
+    #[case::deserialize_nothing(0, None)]
+    #[case::deserialize_default(1, Some(Telemetry::default()))]
+    #[case::deserialize_default_with_remainder(2, Some(Telemetry::default()))]
+    #[case::deserialize_default_with_remainder(4, Some(Telemetry::default()))]
     fn test_simple(#[case] index: usize, #[case] expect: Option<Telemetry>) {
         let mut buffer = [0; 10];
         // Serialize to buffer


### PR DESCRIPTION
[ci: Add GitHub Action to build Rust](https://github.com/broken-motorwerks/telemetry_types/commit/49580e6fcbf926c87150daed04a4ec31c7673b8f)

Problem: We've got a distributed project but no easy way to make sure that each commit is still building.

Solution: Commit in the starter workflow for Rust CI builds.

Testing: Saw that this ran and [failed on broken unit tests](https://github.com/ophilli/telemetry_types/actions/runs/12476013048) and then later [succeeded when the tests were fixed](https://github.com/ophilli/telemetry_types/actions/runs/12479072919) on my fork.

---------------
[test: Fix simple decoding test](https://github.com/broken-motorwerks/telemetry_types/commit/9107657da45b818f0002ca5b724ab40eedef50d3)

Problem: The unit tests for the decoder appeared to assume that
`0x00 as u16` would not deserialize into a Telemetry struct because the
Telemetry stuct contains a u32. This is incorrect because Postcard uses
varint encoding and a Telemetry struct containing only one u32 can be
deserialized from as little as a single u8. This incorrect assumption
meant that the tests were failing.

Solution: Update the tests to demonstrate that as little as 1 byte is
sufficient to deserialize a Telemetry struct.

Testing: Ran `cargo test` and saw that it succeeded.
